### PR TITLE
chore: disable body-max-line-length rule

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,34 +1,6 @@
-const maxLength = (value, max) => {
-	return typeof value === 'string' && value.length <= max;
-}
-
-const maxLineLength = (value, max) => {
-	return typeof value === 'string' &&
-	value.split(/\r?\n/).every((line) => maxLength(line, max));
-}
-
-const bodyMaxLineLength = 100
-
-const validateBodyMaxLengthIgnoringDeps = (parsedCommit) => {
-  const { type, scope, body } = parsedCommit
-  const isDepsCommit =
-    (type === 'chore' || type === 'build') && (scope === 'deps' || scope === 'deps-dev')
-
-  return [
-    isDepsCommit || !body || maxLineLength(body, bodyMaxLineLength),
-    `body's lines must not be longer than ${bodyMaxLineLength}`,
-  ]
-}
-
 module.exports = {
   extends: ['@commitlint/config-conventional'],
-  plugins: ['commitlint-plugin-function-rules'],
   rules: {
     'body-max-line-length': [0],
-    'function-rules/body-max-line-length': [
-      2,
-      'always',
-      validateBodyMaxLengthIgnoringDeps,
-    ],
   },
 }


### PR DESCRIPTION
This did not seem to give us value, rather the opposite, when dependabot PR's were failing due to failed tests.