### PR TITLE
build: mark dev dependencies as hard dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-workflow-semantic-release",
-  "devDependencies": {
+  "dependencies": {
     "conventional-changelog-conventionalcommits": "^5.0.0",
     "semantic-release": "^20.0.3",
     "semantic-release-tags": "^2.0.0"


### PR DESCRIPTION
Dependabot currently commits with prefix `build(dev-deps):`, but these are actual dependencies.

@umglurf @joberget comments? Does this look right?

