### PR TITLE
feat: include body of commit message in release notes

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -13,7 +13,10 @@
       [
         "@semantic-release/release-notes-generator",
         {
-          "preset": "conventionalcommits"
+          "preset": "conventionalcommits",
+          "writerOpts": {
+            "mainTemplate": "{{> header}}\n\n{{#each commitGroups}}\n{{#each commits}}\n{{> commit root=@root}}{{#if body }}{{ body }}{{/if}}\n{{/each}}\n{{/each}}\n\n{{> footer}}\n"
+          }
         }
       ],
       "@semantic-release/github",


### PR DESCRIPTION
Include the full commit message body in the release notes, so that we
get all relevant information in the release and changelog.
