### PR TITLE
feat: add option to enable/disable linting

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -5,6 +5,9 @@ on:
       release-enabled:
         type: boolean
         default: true
+      lint-enabled:
+        type: boolean
+        default: true
       runs-on:
         type: string
         default: nrk-azure-intern
@@ -35,6 +38,7 @@ jobs:
     needs: setup
     name: Commit lint
     runs-on: ${{ inputs.runs-on }}
+    if: inputs.lint-enabled
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -35,5 +35,6 @@ jobs:
 <!-- autodoc start -->
 ### Inputs
 - `release-enabled` (boolean, default `true`)
+- `lint-enabled` (boolean, default `true`)
 - `runs-on` (string, default `"nrk-azure-intern"`)
 <!-- autodoc end -->


### PR DESCRIPTION
To mitigate rate-limit error. default value is true, should not break
older implementations of this workflow
