### PR TITLE
Forslag: skru av automatisk varsling til PR

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -20,6 +20,9 @@
         }
       ],
       "@semantic-release/github",
+      {
+          "successComment": false
+      }
       "semantic-release-tags"
     ]
 }


### PR DESCRIPTION
Hver gang det lages en ny release, sendes det ut et varsel til hver PR som inngår i releasen, i form av en kommentar på den enkelte PR-en. Dette innebærer at dersom du har merget 12 PR-er av typen refactor, doc, style osv, vil du få 12 varsler i Slack om at semantic-release har kommentert i din PR ved neste release. Dette oppleves som støyete.

Foreslår at man heller abonnerer på release-varsel pr repo man ønsker å følge med på.

Ref: https://github.com/semantic-release/github#options