### PR TITLE
fix: add missing comma in releaserc

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -22,7 +22,7 @@
       "@semantic-release/github",
       {
           "successComment": false
-      }
+      },
       "semantic-release-tags"
     ]
 }


### PR DESCRIPTION
Missing comma after f6b56b7ca6d8383e97ec0237cf8542d23251446b