### PR TITLE
fix: increase max footer line length

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
-    'body-max-line-length': [2, 'always', 256]
+    'body-max-line-length': [2, 'always', 256],
+    'footer-max-line-length': [2, 'always', 256]
   },
 }


### PR DESCRIPTION
Defaults to 100. Should _at least_ be possible to set it as long as the body max length.
https://github.com/conventional-changelog/commitlint/blob/master/%40commitlint/config-conventional/index.js#L7