### PR TITLE
fix: set runs-on default to ubuntu-latest

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -10,7 +10,7 @@ on:
         default: true
       runs-on:
         type: string
-        default: nrk-azure-intern
+        default: ubuntu-latest
     outputs:
       # Outputs as described here: https://github.com/codfish/semantic-release-action/blob/main/action.yml#L56
       new-release-published:

--- a/README.md
+++ b/README.md
@@ -36,5 +36,5 @@ jobs:
 ### Inputs
 - `release-enabled` (boolean, default `true`)
 - `lint-enabled` (boolean, default `true`)
-- `runs-on` (string, default `"nrk-azure-intern"`)
+- `runs-on` (string, default `"ubuntu-latest"`)
 <!-- autodoc end -->


### PR DESCRIPTION
Riktig tags for å kjøre på interne runners er `[nrk-azure-intern, linux]`, `nrk-azure-intern` holder ikke.  
Ser ingen grunn til at vi ikke kan defaulte til hosted runner.