### PR TITLE
fix: disable subject case rule

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -2,6 +2,7 @@ module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
     'body-max-line-length': [2, 'always', 256],
-    'footer-max-line-length': [2, 'always', 256]
+    'footer-max-line-length': [2, 'always', 256],
+    'subject-case': [0, 'always', 'lower-case']  // Disable subject case rule
   },
 }


### PR DESCRIPTION
Copy of #134, but with signed commit.

Disable strict subject casing to be closer to the official [conventional commits specification](https://www.conventionalcommits.org/en/v1.0.0/#specification).

Closes #131.