### PR TITLE
fix: set header max length to 200

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -4,6 +4,7 @@ export default {
     'body-max-line-length': [2, 'always', 256],
     'footer-max-line-length': [2, 'always', 256],
     'subject-max-length': [0],
-    'subject-case': [0, 'always', 'lower-case']  // Disable subject case rule
+    'subject-case': [0, 'always', 'lower-case'],  // Disable subject case rule
+    'header-max-length' : [2, 'always', 200]
   },
 };

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -5,6 +5,6 @@ export default {
     'footer-max-line-length': [2, 'always', 256],
     'subject-max-length': [0],
     'subject-case': [0, 'always', 'lower-case'],  // Disable subject case rule
-    'header-max-length' : [2, 'always', 200]
+    'header-max-length': [2, 'always', 200]
   },
 };


### PR DESCRIPTION
This pull request updates the `commitlint.config.mjs` file to enhance commit message validation by introducing a new rule for header length.

### Commit message validation update:
* Added a new rule, `'header-max-length'`, to enforce a maximum header length of 200 characters.