### PR TITLE
fix(ci): correct extraction of workflow tag in GitHub Actions workflow file

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -66,7 +66,7 @@ jobs:
           then
             workflow_file="$(grep -El "^name: (\"|)${GITHUB_WORKFLOW}(\"|)$" .github/workflows/*)"
           fi
-          workflow_tag="$(awk -F @ '/github-workflow-semantic-release/ {print $2}' "${workflow_file}")"
+          workflow_tag="$(awk -F '[[:space:]@]+' '/github-workflow-semantic-release/ {print $4}' "${workflow_file}")"
           echo "workflow_tag=${workflow_tag}" >> $GITHUB_OUTPUT
 
   commitlint:


### PR DESCRIPTION
This allows us to pin to git commit and add a comment with version so that
Renovate can pin to commit and give proper changelogs
